### PR TITLE
Fix file upload handler by adjusting function signatures

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,11 @@
 
 ## Changelog
 
+### Releases v?.?.?
+
+1. Fix file upload to Teensy 4.1 board based on suggestions made on the PJRC forum. Align signatures of file upload handlers.
+For more details, please see this post: [AsyncWebServer_Teensy41 bug onUpload](https://forum.pjrc.com/index.php?threads/asyncwebserver_teensy41-bug-onupload.72220).
+
 ### Releases v1.6.2
 
 1. Add examples [Async_WebSocketsServer](https://github.com/khoih-prog/AsyncWebServer_Teensy41/tree/main/examples/Async_WebSocketsServer) to demo how to use `Async_WebSockets`

--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,7 @@
 
 ## Changelog
 
-### Releases v?.?.?
+### Releases v1.7.0
 
 1. Fix file upload to Teensy 4.1 board based on suggestions made on the PJRC forum. Align signatures of file upload handlers.
 For more details, please see this post: [AsyncWebServer_Teensy41 bug onUpload](https://forum.pjrc.com/index.php?threads/asyncwebserver_teensy41-bug-onupload.72220).

--- a/src/AsyncJson_Teensy41.h
+++ b/src/AsyncJson_Teensy41.h
@@ -405,7 +405,7 @@ class AsyncCallbackJsonWebHandler: public AsyncWebHandler
 
     /////////////////////////////////////////////////
 
-    virtual void handleUpload(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data,
+    virtual void handleUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data,
                               size_t len, bool final) override final
     {
     }

--- a/src/AsyncWebHandlerImpl_Teensy41.h
+++ b/src/AsyncWebHandlerImpl_Teensy41.h
@@ -193,6 +193,14 @@ class AsyncCallbackWebHandler: public AsyncWebHandler
 
     /////////////////////////////////////////////////
 
+    virtual void handleUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) override final
+    {
+      if (_onUpload)
+        _onUpload(request, filename, index, data, len, final);
+    }
+
+    /////////////////////////////////////////////////
+
     virtual void handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index,
                             size_t total) override final
     {

--- a/src/AsyncWebRequest_Teensy41.cpp
+++ b/src/AsyncWebRequest_Teensy41.cpp
@@ -587,7 +587,8 @@ void AsyncWebServerRequest::_handleUploadByte(uint8_t data, bool last)
   if (last || _itemBufferIndex == 1460)
   {
     //check if authenticated before calling the upload
-    if (_handler) {
+    if (_handler) 
+    {
       _handler->handleUpload(this, _itemFilename, _itemSize - _itemBufferIndex, _itemBuffer, _itemBufferIndex, false);
     }
     _itemBufferIndex = 0;

--- a/src/AsyncWebRequest_Teensy41.cpp
+++ b/src/AsyncWebRequest_Teensy41.cpp
@@ -587,9 +587,9 @@ void AsyncWebServerRequest::_handleUploadByte(uint8_t data, bool last)
   if (last || _itemBufferIndex == 1460)
   {
     //check if authenticated before calling the upload
-    if (_handler)
+    if (_handler) {
       _handler->handleUpload(this, _itemFilename, _itemSize - _itemBufferIndex, _itemBuffer, _itemBufferIndex, false);
-
+    }
     _itemBufferIndex = 0;
   }
 }

--- a/src/AsyncWebServer_Teensy41.hpp
+++ b/src/AsyncWebServer_Teensy41.hpp
@@ -629,7 +629,7 @@ class AsyncWebHandler
     /////////////////////////////////////////////////
 
     virtual void handleRequest(AsyncWebServerRequest *request __attribute__((unused))) {}
-    virtual void handleUpload(AsyncWebServerRequest *request  __attribute__((unused)), const String& filename __attribute__((unused)), 
+    virtual void handleUpload(AsyncWebServerRequest *request  __attribute__((unused)), String filename __attribute__((unused)), 
                  size_t index __attribute__((unused)), uint8_t *data __attribute__((unused)), size_t len __attribute__((unused)), 
                  bool final  __attribute__((unused))) {}
     virtual void handleBody(AsyncWebServerRequest *request __attribute__((unused)), uint8_t *data __attribute__((unused)), 
@@ -697,7 +697,7 @@ class AsyncWebServerResponse
  * */
 
 typedef std::function<void(AsyncWebServerRequest *request)> ArRequestHandlerFunction;
-typedef std::function<void(AsyncWebServerRequest *request, /*const String& filename,*/ size_t index, uint8_t *data, size_t len, bool final)> ArUploadHandlerFunction;
+typedef std::function<void(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final)> ArUploadHandlerFunction;
 typedef std::function<void(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total)> ArBodyHandlerFunction;
 
 /////////////////////////////////////////////////////////


### PR DESCRIPTION
This branch intends to fix the file upload feature of the async web server.
As seen icw with the Teensy 4.1 board.

When one uploads a file through the web server the appropriate handlers aren't called.
Or perhaps only the default implementation of the virtual method is called which does nothing.

This PR changes the signatures of the file upload handler methods in an attempt to fix that.

The fix was originally proposed by member Shuptuu of the PJRC forum:

https://forum.pjrc.com/index.php?threads/asyncwebserver_teensy41-bug-onupload.72220
