### PR TITLE
Fix Crash when removing non interesting Headers

### DIFF
--- a/src/AsyncWebRequest_Teensy41.cpp
+++ b/src/AsyncWebRequest_Teensy41.cpp
@@ -271,13 +271,18 @@ void AsyncWebServerRequest::_removeNotInterestingHeaders()
 {
   if (_interestingHeaders.containsIgnoreCase("ANY"))
     return; // nothing to do
-
-  for (const auto& header : _headers)
-  {
-    if (!_interestingHeaders.containsIgnoreCase(header->name().c_str()))
+    
+  bool removing = true;
+  while(removing) {
+    for (const auto& header : _headers)
     {
-      _headers.remove(header);
+      if (!_interestingHeaders.containsIgnoreCase(header->name().c_str()))
+      {
+        _headers.remove(header);
+        break; // break and restart the _headers iteration, if we keep iterating the linked List with a deleted element this may cause a Mem Access violation
+      }
     }
+    removing = false;
   }
 }
 


### PR DESCRIPTION
The deletion of non interesting Headers while iterating the _headers LinkedList in some cases causes a crash.

The PR fixes the issue be restaring the iteration through _headers when an element has been deleted.